### PR TITLE
Added command line arguments to add advanced usability

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,21 @@
 # Rimlink
+
+## Update 2020-12-21
+* Added functionality to skip admin requirement via commandline argument `--noadmin` for users that have saved their game file outside of protected directories
+* Added functionality to allow users to add a commandline parameter to specify custom save location via `--savedatafolder "folderpath"`
+
+## Syntax
+To run rimlink as a non-admin, you should start via command line as follows:
+```
+rimlink.exe --noadmin # allows running rimlink as not an admin
+```
+
+To run rimlink from a custom saved location, you should start via command line as follows:
+```
+rimlink.exe --noadmin --savedatafolder "your path here wrapped in doublequotes"
+```
+
+
 The purpose of this utility is to sync rimworld mods, updates, and config folders between a host and multiple users. This will help with reduce the frequency of desyncs when using the multiplayer mod. It only works for Windows as I do not have access to a Mac.
 
 In order to use:

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # Rimlink
 
+---
 ## Update 2020-12-21
 * Added functionality to skip admin requirement via commandline argument `--noadmin` for users that have saved their game file outside of protected directories
 * Added functionality to allow users to add a commandline parameter to specify custom save location via `--savedatafolder "folderpath"`
@@ -14,7 +15,7 @@ To run rimlink from a custom saved location, you should start via command line a
 ```
 rimlink.exe --noadmin --savedatafolder "your path here wrapped in doublequotes"
 ```
-
+---
 
 The purpose of this utility is to sync rimworld mods, updates, and config folders between a host and multiple users. This will help with reduce the frequency of desyncs when using the multiplayer mod. It only works for Windows as I do not have access to a Mac.
 

--- a/main.py
+++ b/main.py
@@ -4,6 +4,7 @@ import asyncio
 import re
 import os
 import time
+import sys # for sys.argv command line arguments
 import pickle
 import socket
 from shutil import rmtree
@@ -123,7 +124,7 @@ def automaticSync(packets):
 def client():
     sync_config = menu("Do you want to sync config files as well? \n(y)es\n(n)o", yesNoValidator)
     if sync_config == "y":
-        if not isAdmin():
+        if not isAdmin(sys.argv):
             print("In order to sync config files the program must be run with administrator privileges.")
             hangForever()
         sync_config = True
@@ -311,7 +312,7 @@ def main():
     if not requireRimworldFolder():
         print("You must put this file into the top directory of the rimworld folder")
         hangForever()
-    if not isAdmin():
+    if not isAdmin(sys.argv):
         print("You must run in administrator mode")
         hangForever()
     host = menu("Are you hosting the rimworld server?\n(y)es\n(n)o", yesNoValidator)

--- a/rimlink.py
+++ b/rimlink.py
@@ -9,14 +9,13 @@ SCRIPT_LOCATION = ""
 
 
 def isAdmin(cmdLine=None):
-    if not cmdLine:
+    if not '--noadmin' in cmdLine:
         try:
             is_admin = (os.getuid() == 0)
         except AttributeError:
             is_admin = ctypes.windll.shell32.IsUserAnAdmin() != 0
     else:
-        if '--noadmin' in cmdLine:
-            is_admin = True
+        is_admin = True
     return is_admin
 
 class FileFolder:
@@ -98,10 +97,15 @@ class AppDataStructure(HashStructure):
         else:
             return AppDataStructure.getRimworldConfigArea()
     @staticmethod
-    def getRimworldConfigArea():
-        roaming = os.getenv("APPDATA")
-        app_data = "\\".join(roaming.split("\\")[:-1])
-        return os.path.join(os.path.join(os.path.join(app_data, "LocalLow"), "Ludeon Studios"), "RimWorld by Ludeon Studios")
+    def getRimworldConfigArea(cmdLine=None):
+        if not '--savedatafolder' in cmdLine:
+            roaming = os.getenv("APPDATA")
+            app_data = "\\".join(roaming.split("\\")[:-1])
+            return os.path.join(os.path.join(os.path.join(app_data, "LocalLow"), "Ludeon Studios"), "RimWorld by Ludeon Studios")
+        else:
+            pass
+#TODO: add this in            
+            
 
 
 FILE_EXCEPTIONS = ["__pycache__", "Saves", "Scenarios", "MpReplays", "MpDesyncs", "Player.log", "Player-prev.log", ".gitignore", ".git", "rimlink.exe"]

--- a/rimlink.py
+++ b/rimlink.py
@@ -8,11 +8,15 @@ from filecmp import cmp
 SCRIPT_LOCATION = ""
 
 
-def isAdmin():
-    try:
-        is_admin = (os.getuid() == 0)
-    except AttributeError:
-        is_admin = ctypes.windll.shell32.IsUserAnAdmin() != 0
+def isAdmin(cmdLine=None):
+    if not cmdLine:
+        try:
+            is_admin = (os.getuid() == 0)
+        except AttributeError:
+            is_admin = ctypes.windll.shell32.IsUserAnAdmin() != 0
+    else:
+        if '--noadmin' in cmdLine:
+            is_admin = True
     return is_admin
 
 class FileFolder:

--- a/rimlink.py
+++ b/rimlink.py
@@ -8,7 +8,7 @@ from filecmp import cmp
 SCRIPT_LOCATION = ""
 
 
-def isAdmin(cmdLine=None):
+def isAdmin(cmdLine=[]):
     if not '--noadmin' in cmdLine:
         try:
             is_admin = (os.getuid() == 0)
@@ -97,14 +97,15 @@ class AppDataStructure(HashStructure):
         else:
             return AppDataStructure.getRimworldConfigArea()
     @staticmethod
-    def getRimworldConfigArea(cmdLine=None):
+    def getRimworldConfigArea(cmdLine=[]):
         if not '--savedatafolder' in cmdLine:
             roaming = os.getenv("APPDATA")
             app_data = "\\".join(roaming.split("\\")[:-1])
-            return os.path.join(os.path.join(os.path.join(app_data, "LocalLow"), "Ludeon Studios"), "RimWorld by Ludeon Studios")
+            save_location = os.path.join(os.path.join(os.path.join(app_data, "LocalLow"), "Ludeon Studios"), "RimWorld by Ludeon Studios")
         else:
-            pass
-#TODO: add this in            
+            save_location = sys.argv[sys.argv.index("--savedatafolder")+1].replace('"','')
+        return save_location
+            
             
 
 


### PR DESCRIPTION
I’ve added some command line arguments that should resolve the two open issues.  They allow an advanced user to use the noadmin flag and the savedatafolder flag to bypass and redirect those areas.